### PR TITLE
👷 add publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+name: Publish image
+
+on:
+  schedule:
+    - cron: '0 1 * * 3'
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  call-publish:
+    uses: vscode-devcontainers/actions/.github/workflows/publish.yml@main


### PR DESCRIPTION
GitHub Action to build, publish and sign the container image.
Platforms: `linux/amd64` `linux/arm64`